### PR TITLE
Bugfix: Don't send empty ticket parameter.

### DIFF
--- a/lib/cloudprint/printer.rb
+++ b/lib/cloudprint/printer.rb
@@ -20,7 +20,14 @@ module CloudPrint
     def print(options)
       content = options[:content]
       method = content.is_a?(IO) || content.is_a?(StringIO) || content.is_a?(Tempfile) ? :multipart_post : :post
-      response = client.connection.send(method, '/submit', :printerid => self.id, :title => options[:title], :content => options[:content], :ticket => options[:ticket].to_json, :contentType => options[:content_type]) || {}
+      params = {
+        printerid: self.id,
+        title: options[:title],
+        content: options[:content],
+        contentType: options[:content_type]
+      }
+      params[:ticket] = options[:ticket].to_json if options[:ticket] && options[:ticket] != ''
+      response = client.connection.send(method, '/submit', params) || {}
       return nil if response.nil? || response["job"].nil?
       client.print_jobs.new_from_response response["job"]
     end


### PR DESCRIPTION
We use code like this to print a PDF document: 
```
CLOUD_PRINT = CloudPrint::Client.new(...)
printer = CLOUD_PRINT.printers.find(CLOUD_PRINT_PRINTER_ID)
printer.print(content: to_pdf, content_type: 'application/pdf', title: file_name)
```
which worked fine in 0.2.1. When updating to version >= 0.3.0 enqueuing the job fails with an errorCode 424: "Failed to parse the print job's print ticket"

The reason seems to be, that the gem now always sends the ticket parameter, even if it's empty. But CloudPrint can't parse the ticket options in that case and fails. This PR fixes that by only adding the `ticket` param if it's non-empty.